### PR TITLE
change returnTx response to be JSON encoded when successful

### DIFF
--- a/app/controllers/Controller.scala
+++ b/app/controllers/Controller.scala
@@ -3,6 +3,7 @@ package controllers
 import akka.actor.ActorSystem
 import dao.{AssemblyReqDAO, ReqSummaryDAO}
 import io.circe.Json
+import io.circe.syntax._
 import javax.inject._
 import models.{Assembly, Summary}
 import play.api.Logger
@@ -100,7 +101,7 @@ class Controller @Inject()(cc: ControllerComponents, actorSystem: ActorSystem,
 
   def returnTx(mine: String, address: String): Action[AnyContent] = Action { implicit request: Request[AnyContent] =>
     try {
-      Ok(nodeService.returnFunds(mine, address)).as("application/json")
+      Ok(nodeService.returnFunds(mine, address).asJson).as("application/json")
     } catch {
       case e: Exception =>
         errorResponse(e)


### PR DESCRIPTION
Currently when `returnTx` is successful, it returns a `string` but does not encode as JSON by wrapping in quotes.  This simple fix calls circe's `.asJson`.

see https://discord.com/channels/668903786361651200/808434850356920340/885582687195246592 for originating discussion.

